### PR TITLE
Add redirect rules to Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,14 @@
 [build]
   functions = "./functions"
+
+[[redirects]]
+  from = "https://chanoformayor.com/*"
+  to = "https://chano4mayor.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://laughing-meninsky-b1c0c6.netlify.com/*"
+  to = "https://chano4mayor.com/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
## Overview

Add two `[[redirects]]` blocks to netlify.toml to specify that the Netlify subdomain and chanoformayor.com should both redirect to chano4mayor.com.

## Testing instructions

* Since this is a Netlify config setting, not sure how to test it other than to pull it in and see if it works...